### PR TITLE
change get hasLanguagePatches to internal

### DIFF
--- a/LanguagePatches/LanguageAPI.cs
+++ b/LanguagePatches/LanguageAPI.cs
@@ -28,7 +28,7 @@ namespace LanguagePatches
         /// <summary>
         /// Whether the Language Patches Assembly is there
         /// </summary>
-        private static Boolean hasLanguagePatches { get; set; }
+        internal static Boolean hasLanguagePatches { get; private set; }
 
         static LanguageAPI()
         {


### PR DESCRIPTION
Hello, I think it can be useful to be able to enable/disable the translation of our mod on a config window.

You can see how I've used your API : https://github.com/malahx/QuickMods/blob/master/QuickContracts/QC_Lang.cs#L43