### PR TITLE
corrected errors with assembly which aren't loaded

### DIFF
--- a/LanguagePatches/LanguageAPI.cs
+++ b/LanguagePatches/LanguageAPI.cs
@@ -32,7 +32,7 @@ namespace LanguagePatches
 
         static LanguageAPI()
         {
-            Type[] types = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).ToArray();
+            Type[] types = AssemblyLoader.loadedAssemblies.SelectMany (a => a.assembly.GetTypes ()).ToArray ();
             Type languagePatches = types.FirstOrDefault(t => t.Name == "LanguagePatches");
             if (languagePatches != null)
             {


### PR DESCRIPTION
Hello, the API try to getTypes from not loaded plugins (example : a plugin which aren't updated for the last version of KSP).

> ReflectionTypeLoadException: The classes in the module cannot be loaded.
  at (wrapper managed-to-native) System.Reflection.Assembly:GetTypes (bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <filename unknown>:0 
  at LanguagePatches.LanguageAPI.<LanguageAPI>m__0 (System.Reflection.Assembly a) [0x00000] in <filename unknown>:0 
  at System.Linq.Enumerable+<CreateSelectManyIterator>c__Iterator12`2[System.Reflection.Assembly,System.Type].MoveNext () [0x00000] in <filename unknown>:0 
  at System.Collections.Generic.List`1[System.Type].AddEnumerable (IEnumerable`1 enumerable) [0x00000] in <filename unknown>:0 
  at System.Collections.Generic.List`1[System.Type]..ctor (IEnumerable`1 collection) [0x00000] in <filename unknown>:0 
  at System.Linq.Enumerable.ToArray[Type] (IEnumerable`1 source) [0x00000] in <filename unknown>:0 
  at LanguagePatches.LanguageAPI..cctor () [0x00000] in <filename unknown>:0 
Rethrow as TypeInitializationException: An exception was thrown by the type initializer for LanguagePatches.LanguageAPI
  at QuickBrake.QLang.translate (System.String lang, System.String text) [0x00000] in <filename unknown>:0 
  at QuickBrake.QLang.translate (System.String text) [0x00000] in <filename unknown>:0 
  at QuickBrake.QBlizzyToolbar.Start () [0x00000] in <filename unknown>:0 
  at QuickBrake.QGUI.Start () [0x00000] in <filename unknown>:0  

I've seen this error with mods like ShowFPS & AnomalySurveyor which are compiled for KSP 1.1.X